### PR TITLE
Foundry v13 Compatibility Fix

### DIFF
--- a/styles/theme.css
+++ b/styles/theme.css
@@ -182,9 +182,19 @@ body {
 		box-shadow: var(--pfu-control-shadow);
 	}
 }
-/*random bullshit*/
+/*Quick Fixes*/
 .application .window-content {
 	background: var(--pfu-color-app-body-primary-fill);
+}
+.resource-inputs,
+.combineBar,
+.bond-strength,
+.traits.resource-content input {
+	background: var(--pfu-color-app-control-fill)
+}
+.resource-label-m,
+.resource-content {
+	background: #00000000;
 }
 .projectfu .sheet-header .profile-img {
 	background: var(--pfu-color-app-body-primary-fill);
@@ -198,7 +208,6 @@ button.plain {
 button.plain:hover {
 	color: var(--pfu-color-control-focus-content);
 }
-/* Theme Start */
 li.folder>.folder-header .create-button {
 	&:hover {
 		color: var(--pfu-color-control-focus-content);
@@ -211,8 +220,6 @@ li.folder>.folder-header .create-button {
 }
 .window-content section button,
 .sidebar-tab .header-actions button,
-/* .sidebar-tab nav.encounters button, */
-/* .sidebar-tab a.button, */
 .chat-input,
 .ui-control {
 	color: var(--pfu-color-control-content);
@@ -226,7 +233,6 @@ li.folder>.folder-header .create-button {
 .window-content section button:hover,
 .sidebar-tab .header-actions button:hover,
 .sidebar-tab nav.encounters button:hover,
-/* .sidebar-tab a.button:hover */
 .ui-control:hover
 { 
 	color: var(--pfu-color-control-highlight-content);
@@ -237,7 +243,6 @@ li.folder>.folder-header .create-button {
 .window-content section button.active,
 .sidebar-tab .header-actions button.active,
 .sidebar-tab nav.encounters button.active,
-/* .sidebar-tab a.button.active */
 .ui-control.active
 {
 	border-color: var(--pfu-color-control-active-border);
@@ -259,6 +264,7 @@ li.folder>.folder-header .create-button {
 	opacity: .5;
 }
 
+/* Theme Start */
 /* #scene-navigation {
 
 	& li:hover {
@@ -514,7 +520,7 @@ a.inline-macro-execution {
 	background: var(--pfu-color-app-control-fill);
 	box-shadow: 0.063rem 0.1rem var(--pfu-color-app-control-shadow);
 	border: 0.063rem solid var(--pfu-color-app-control-border);
-	text-shadow: 1px 1px var(--pfu-color-app-control-content-shadow);
+	text-shadow: 1px 1px var(--resource-inpupfu-color-app-control-content-shadow);
 
 	& i {
 		color: var(--pfu-color-app-control-content);
@@ -630,7 +636,7 @@ a.inline-macro-execution {
 	}
 }
 
-.projectfu#combat-hud {
+/* .projectfu#combat-hud {
 	& .faction-list .combat-row {
 		color: var(--pfu-color-app-item-header-content);
 		text-shadow: 1px 1px var(--pfu-color-app-item-header-content-shadow, black);
@@ -642,7 +648,7 @@ a.inline-macro-execution {
 		box-shadow: 3px 3px var(--pfu-color-app-item-header-shadow);
 		background: var(--pfu-color-app-item-header-fill);
 	}
-}
+} */
 
 
 	.chat-message,
@@ -970,7 +976,7 @@ a.inline-macro-execution {
 :is(.backgroundstyle, .unique-dialog, #auto-target-dialog, #auto-spend-dialog .application) {
 
 	/* Reset to foundry defaults to fix wonky styling on headers due to the background covering it too. */
-	background: url("/ui/denim075.png") repeat;
+	/* background: url("/ui/denim075.png") repeat; */
 	background-blend-mode: unset;
 	background-repeat: unset;
 	background-position: unset;
@@ -1150,7 +1156,6 @@ a.inline-macro-execution {
 		}
 
 		& .sheet-header {
-			&>.combine-header {
 
 				& .profile-img,
 				.item-profile-img {
@@ -1221,7 +1226,6 @@ a.inline-macro-execution {
 
 							&.pronouns {
 								text-shadow: 1px 1px 1px var(--pfu-color-app-name-section-shadow);
-							}
 						}
 					}
 				}


### PR DESCRIPTION
Since the issues with the theme were largely changed classes in the v13 DOM, I changed them where appropriate and I some cases ignored more specific selectors, in certain areas where broader application seemed appropriate, particularly with buttons (since the .ui-control class seems to function perfectly for changing most of them without any side effects).

Ultimately I think there might be a simpler way to go about some of these style changes, but for now I have only commented out the stuff that either doesn't work or that I replaced with simpler selectors. There's likely a lot of superfluous stuff there but I wanted to get something that works for now out before I start tidying up the CSS where I can.